### PR TITLE
feat: implement RadioCard component with styled and test cases

### DIFF
--- a/choreo-ui/workspaces/libs/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { StyledCheckbox } from './Checkbox.styled';
-import { Checkbox as MUICheckbox } from '@mui/material';
+import {
+  Checkbox as MUICheckbox,
+  CheckboxProps as MuiCheckboxProps,
+} from '@mui/material';
 
 export type CheckboxSize = 'small' | 'medium';
 
@@ -13,7 +16,7 @@ export type CheckboxColor =
   | 'info'
   | 'success';
 
-export interface CheckboxProps {
+export interface CheckboxProps extends MuiCheckboxProps {
   children?: React.ReactNode;
   className?: string;
   onClick?: (event: React.MouseEvent) => void;
@@ -46,12 +49,7 @@ export const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(
     ref
   ) => {
     return (
-      <StyledCheckbox
-        ref={ref}
-        className={className}
-        disabled={disabled}
-        {...props}
-      >
+      <StyledCheckbox ref={ref} className={className} disabled={disabled}>
         <MUICheckbox
           {...props}
           className={className}

--- a/choreo-ui/workspaces/libs/design-system/src/components/Radio/RadioIndicator.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/Radio/RadioIndicator.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { StyledRadioIndicator } from './Radio.styled';
+import { RadioProps } from '@mui/material';
 
-export const RadioIndicator = React.forwardRef<HTMLDivElement>((props) => {
-  return (
-    <StyledRadioIndicator
-      {...props}
-      disableRipple={true}
-      disableFocusRipple={true}
-      disableTouchRipple={true}
-    />
-  );
-});
+export const RadioIndicator = React.forwardRef<HTMLDivElement, RadioProps>(
+  (props) => {
+    return (
+      <StyledRadioIndicator
+        {...props}
+        disableRipple={true}
+        disableFocusRipple={true}
+        disableTouchRipple={true}
+      />
+    );
+  }
+);
 
 RadioIndicator.displayName = 'RadioIndicator';

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.stories.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.stories.tsx
@@ -1,0 +1,581 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadioCard } from './RadioCard';
+import React from 'react';
+import {
+  Box,
+  Grid,
+  IconButton,
+  ListItemIcon,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import { Card, CardContent } from '../Card';
+import { RadioGroup } from '../RadioGroup';
+import ChoreoNotificationImg from '../../Images/generated/ServiceColor';
+import Edit from '@design-system/Icons/generated/Edit';
+import Delete from '@design-system/Icons/generated/Delete';
+import { MoreVert } from '@mui/icons-material';
+
+const meta: Meta<typeof RadioCard> = {
+  title: 'Choreo DS/RadioCard',
+  component: RadioCard,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Disables the element',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+};
+
+const testId = 'radio-card';
+
+export default meta;
+type Story = StoryObj<typeof RadioCard>;
+
+export const VerticalTemplate: Story = {
+  render: function Template(_args) {
+    const [value, setValue] = React.useState('restAPI');
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue((event.target as HTMLInputElement).value);
+    };
+    return (
+      <Box maxWidth={800}>
+        <Card testId={`${testId}-vertical`}>
+          <CardContent>
+            <RadioGroup
+              defaultValue="restAPI"
+              aria-label="apiType"
+              name="apiType"
+              value={value}
+              onChange={handleChange}
+              testId="vertical-default-options"
+            >
+              <RadioCard
+                title="RestAPI"
+                description="This report contains data related to response mediation latency in all the API versions."
+                value="restAPI"
+                active={value === 'restAPI'}
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-api`}
+              />
+              <RadioCard
+                title="API Proxy"
+                description="API Proxy Desc"
+                value="apiProxy"
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-proxy`}
+              />
+              <RadioCard
+                title="Other"
+                description="Other Desc"
+                value="other"
+                active={value === 'other'}
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-other`}
+              />
+              <RadioCard
+                title="Disabled"
+                description="Disabled Desc"
+                value="disabled"
+                active={value === 'disabled'}
+                icon={<ChoreoNotificationImg />}
+                disabled
+                testId={`${testId}-disabled`}
+              />
+            </RadioGroup>
+          </CardContent>
+        </Card>
+      </Box>
+    );
+  },
+};
+
+export const HorizontalTemplate: Story = {
+  render: function HorizontalTemplate(_args) {
+    const [value, setValue] = React.useState('restAPI');
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue((event.target as HTMLInputElement).value);
+    };
+    return (
+      <Box p={5}>
+        <RadioGroup
+          defaultValue="restAPI"
+          aria-label="ApiType"
+          name="apiType"
+          value={value}
+          onChange={handleChange}
+          direction="row"
+          testId="horizaontal-default-options"
+        >
+          <Grid container spacing={3}>
+            <Grid size={{ xs: 12, md: 4, lg: 4, xl: 3 }}>
+              <RadioCard
+                title="RestAPI"
+                description="RestAPI Description goes here, RestAPI long description goes here"
+                value="restAPI"
+                active={value === 'restAPI'}
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-horizontal-rest`}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 4, lg: 4, xl: 3 }}>
+              <RadioCard
+                title="API Proxy"
+                description="API Proxy Description goes here"
+                value="apiProxy"
+                active={value === 'apiProxy'}
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-horizontal-proxy`}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 4, lg: 4, xl: 3 }}>
+              <RadioCard
+                title="Other"
+                description="Other description."
+                value="other"
+                active={value === 'other'}
+                icon={<ChoreoNotificationImg />}
+                testId={`${testId}-horizontal-other`}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 4, lg: 4, xl: 3 }}>
+              <RadioCard
+                title="Disabled"
+                description="Disabled Description goes here"
+                value="disabled"
+                active={value === 'disabled'}
+                icon={<ChoreoNotificationImg />}
+                disabled
+                testId={`${testId}-horizontal-disabled`}
+              />
+            </Grid>
+          </Grid>
+        </RadioGroup>
+      </Box>
+    );
+  },
+};
+
+export const IndicatorTemplate: Story = {
+  render: function IndicatorTemplate(_args) {
+    const [value, setValue] = React.useState('restAPI');
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue((event.target as HTMLInputElement).value);
+    };
+    return (
+      <Box display="flex" gap={8}>
+        <Box maxWidth={500}>
+          <Card testId={`${testId}-horizontal-1`}>
+            <CardContent>
+              <RadioGroup
+                defaultValue="restAPI"
+                aria-label="apiType"
+                name="apiType1"
+                value={value}
+                onChange={handleChange}
+                testId="indicator-default-options"
+              >
+                <RadioCard
+                  title="RestAPI"
+                  description="This report contains data related to response mediation latency in all the API versions."
+                  value="restAPI"
+                  active={value === 'restAPI'}
+                  indicator={true}
+                  testId={`${testId}-indicator-rest`}
+                />
+                <RadioCard
+                  title="API Proxy"
+                  description="API Proxy Desc"
+                  value="apiProxy"
+                  active={value === 'apiProxy'}
+                  indicator={true}
+                  testId={`${testId}-indicator-proxy`}
+                />
+                <RadioCard
+                  title="Other"
+                  description="Other Desc"
+                  value="other"
+                  active={value === 'other'}
+                  indicator={true}
+                  testId={`${testId}-indicator-other`}
+                />
+                <RadioCard
+                  title="Disabled"
+                  description="Disabled Desc"
+                  value="disabled"
+                  active={value === 'disabled'}
+                  indicator={true}
+                  disabled
+                  testId={`${testId}-indicator-disabled`}
+                />
+              </RadioGroup>
+            </CardContent>
+          </Card>
+        </Box>
+        <Box maxWidth={500}>
+          <Card testId={`${testId}-horizontal-2`}>
+            <CardContent>
+              <RadioGroup
+                defaultValue="restAPI"
+                aria-label="apiType"
+                name="apiType2"
+                testId="indicator-icon-default-options"
+                value={value}
+                onChange={handleChange}
+              >
+                <RadioCard
+                  title="RestAPI"
+                  description="This report contains data related to response mediation latency in all the API versions."
+                  value="restAPI"
+                  active={value === 'restAPI'}
+                  icon={<ChoreoNotificationImg />}
+                  indicator
+                  testId={`${testId}-indicator-icon-rest-desc`}
+                />
+                <RadioCard
+                  title="API Proxy"
+                  description="API Proxy Desc"
+                  value="apiProxy"
+                  active={value === 'apiProxy'}
+                  icon={<ChoreoNotificationImg />}
+                  indicator
+                  testId={`${testId}-indicator-icon-proxy-desc`}
+                />
+                <RadioCard
+                  title="Other"
+                  description="Other Desc"
+                  value="other"
+                  active={value === 'other'}
+                  icon={<ChoreoNotificationImg />}
+                  indicator
+                  testId={`${testId}-indicator-icon-other-desc`}
+                />
+                <RadioCard
+                  title="Disabled"
+                  description="Disabled Desc"
+                  value="disabled"
+                  active={value === 'disabled'}
+                  icon={<ChoreoNotificationImg />}
+                  indicator
+                  disabled
+                  testId={`${testId}-indicator-icon-disabled-desc`}
+                />
+              </RadioGroup>
+            </CardContent>
+          </Card>
+        </Box>
+      </Box>
+    );
+  },
+};
+
+export const IndicatorTemplateContent: Story = {
+  render: function IndicatorTemplateContent(_args) {
+    const [value, setValue] = React.useState('restAPI');
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue((event.target as HTMLInputElement).value);
+    };
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+      setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+      setAnchorEl(null);
+    };
+
+    const actionsTwoItems = (
+      <Box display="flex" gap={8}>
+        <IconButton color="secondary" size="small">
+          <Edit fontSize="inherit" />
+        </IconButton>
+        <IconButton color="secondary" size="small">
+          <Delete fontSize="inherit" />
+        </IconButton>
+      </Box>
+    );
+    const actionsMoreItems = (
+      <div>
+        <IconButton
+          aria-label="more"
+          aria-controls="long-menu"
+          aria-haspopup="true"
+          onClick={handleClick}
+          size="small"
+        >
+          <MoreVert color="secondary" fontSize="small" />
+        </IconButton>
+        <Menu
+          id="long-menu"
+          anchorEl={anchorEl}
+          keepMounted
+          open={open}
+          onClose={handleClose}
+        >
+          <MenuItem>
+            <ListItemIcon>
+              <Edit />
+            </ListItemIcon>
+            <Typography variant="inherit">Edit</Typography>
+          </MenuItem>
+          <MenuItem>
+            <ListItemIcon>
+              <Delete />
+            </ListItemIcon>
+            <Typography variant="inherit">Delete</Typography>
+          </MenuItem>
+        </Menu>
+      </div>
+    );
+
+    return (
+      <>
+        <Box display="flex" gap={8}>
+          <Box>
+            <Card testId={`${testId}-horizontal-3`}>
+              <CardContent>
+                <RadioGroup
+                  defaultValue="restAPI"
+                  aria-label="apiType"
+                  name="apiType1"
+                  value={value}
+                  onChange={handleChange}
+                  testId="story-indicator-default-options"
+                >
+                  <RadioCard
+                    title="RestAPI"
+                    value="restAPI"
+                    active={value === 'restAPI'}
+                    icon={<ChoreoNotificationImg />}
+                    indicator
+                    testId={`${testId}-indicator-rest-desc`}
+                  />
+                  <RadioCard
+                    title="API Proxy"
+                    description="API Proxy Desc"
+                    value="apiProxy"
+                    active={value === 'apiProxy'}
+                    icon={<ChoreoNotificationImg />}
+                    indicator
+                    testId={`${testId}-indicator-proxy-desc`}
+                  />
+                  <RadioCard
+                    title="Other"
+                    description="Other Desc"
+                    value="other"
+                    active={value === 'other'}
+                    icon={<ChoreoNotificationImg />}
+                    indicator
+                    testId={`${testId}-indicator-other-desc`}
+                  />
+                  <RadioCard
+                    title="Disabled"
+                    description="Disabled Desc"
+                    value="disabled"
+                    active={value === 'disabled'}
+                    icon={<ChoreoNotificationImg />}
+                    indicator
+                    disabled
+                    testId={`${testId}-indicator-disabled-desc`}
+                  />
+                </RadioGroup>
+              </CardContent>
+            </Card>
+          </Box>
+          <Box>
+            <Card testId={`${testId}-horizontal-4`}>
+              <CardContent>
+                <RadioGroup
+                  defaultValue="restAPI"
+                  aria-label="apiType"
+                  name="apiType2"
+                  value={value}
+                  onChange={handleChange}
+                  testId="story-apiType2-indicator-default-options"
+                >
+                  <RadioCard
+                    title="RestAPI"
+                    value="restAPI"
+                    active={value === 'restAPI'}
+                    icon={<ChoreoNotificationImg />}
+                    actions={actionsTwoItems}
+                    testId={`${testId}-indicator-icon-rest`}
+                    content={
+                      <Box display="flex" flexDirection="column">
+                        <Typography variant="body1" color="secondary">
+                          This report contains data related to response
+                          mediation latency in all the API versions.
+                        </Typography>
+                      </Box>
+                    }
+                  />
+                  <RadioCard
+                    title="API Proxy"
+                    description="API Proxy Desc"
+                    value="apiProxy"
+                    active={value === 'apiProxy'}
+                    icon={<ChoreoNotificationImg />}
+                    actions={actionsTwoItems}
+                    testId={`${testId}-indicator-icon-proxy`}
+                  />
+                  <RadioCard
+                    title="Other"
+                    description="Other Desc"
+                    value="other"
+                    active={value === 'other'}
+                    icon={<ChoreoNotificationImg />}
+                    actions={actionsMoreItems}
+                    testId={`${testId}-indicator-icon-other`}
+                  />
+                  <RadioCard
+                    title="Disabled"
+                    description="Disabled Desc"
+                    value="disabled"
+                    active={value === 'disabled'}
+                    icon={<ChoreoNotificationImg />}
+                    actions={actionsTwoItems}
+                    disabled
+                    testId={`${testId}-indicator-icon-disabled`}
+                  />
+                </RadioGroup>
+              </CardContent>
+            </Card>
+          </Box>
+        </Box>
+        <Box maxWidth={500} mt={3}>
+          <Typography variant="h3" gutterBottom>
+            Icon Placement
+          </Typography>
+          <Card testId={`${testId}-horizontal-5`}>
+            <CardContent>
+              <RadioGroup
+                defaultValue="restAPI"
+                aria-label="apiType"
+                name="apiType2"
+                value={value}
+                onChange={handleChange}
+                testId="story-action-indicator-default-options"
+              >
+                <RadioCard
+                  title="RestAPI"
+                  value="restAPI"
+                  active={value === 'restAPI'}
+                  icon={<ChoreoNotificationImg />}
+                  actions={actionsTwoItems}
+                  iconPlacement="top"
+                  content={
+                    <Box display="flex" flexDirection="column">
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                    </Box>
+                  }
+                  testId={`${testId}-indicator-icon-rest`}
+                />
+                <RadioCard
+                  title="API Proxy"
+                  description="API Proxy Desc"
+                  value="apiProxy"
+                  active={value === 'apiProxy'}
+                  icon={<ChoreoNotificationImg />}
+                  actions={actionsTwoItems}
+                  testId={`${testId}-indicator-icon-proxy`}
+                  iconPlacement="center"
+                  content={
+                    <Box display="flex" flexDirection="column">
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                      <Typography variant="body1" color="secondary">
+                        This report contains data related to response mediation
+                        latency in all the API versions.
+                      </Typography>
+                    </Box>
+                  }
+                />
+              </RadioGroup>
+            </CardContent>
+          </Card>
+        </Box>
+      </>
+    );
+  },
+};
+
+export const CheckboxContentIndicatorTemplate: Story = {
+  render: function CheckboxContentIndicatorTemplate(_args) {
+    const [selectedItems, setSelectedItems] = React.useState<string[]>([]);
+    const handleSelect = (
+      event: React.ChangeEvent<HTMLInputElement>,
+      value: string
+    ) => {
+      if (event.target.checked) {
+        setSelectedItems((prevSelectedItems) => [...prevSelectedItems, value]);
+      } else {
+        setSelectedItems((prevSelectedItems) =>
+          prevSelectedItems.filter((item) => item !== value)
+        );
+      }
+    };
+
+    const values = ['Rest API', 'API Proxy', 'Cron Job'];
+    return (
+      <Box display="flex" gap={8} maxWidth={500}>
+        <Card testId={`${testId}-radio-card`}>
+          <CardContent>
+            {values.map((value) => (
+              <Box mb={2} key={value}>
+                <RadioCard
+                  key={value}
+                  title={value}
+                  description={`This report contains data related to response mediation
+                  latency in all the ${value} versions.`}
+                  value={value}
+                  active={selectedItems.includes(value)}
+                  icon={<ChoreoNotificationImg />}
+                  indicator
+                  enableCheckboxMode
+                  onToggleSelect={(event) => handleSelect(event, value)}
+                  testId={`${testId}-indicator-icon-${value}-desc`}
+                />
+              </Box>
+            ))}
+          </CardContent>
+        </Card>
+      </Box>
+    );
+  },
+};

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.styled.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.styled.tsx
@@ -1,0 +1,125 @@
+import { alpha, Box, BoxProps, styled } from '@mui/material';
+import { ComponentType } from 'react';
+
+export interface StyledRadioCardProps extends BoxProps {
+  disabled?: boolean;
+}
+
+export const StyledRadioCard: ComponentType<StyledRadioCardProps> = styled(
+  Box
+)<StyledRadioCardProps>(({ theme }) => ({
+  '& .radioCard': {
+    position: 'relative',
+    height: '100%',
+    width: '100%',
+  },
+
+  '& [data-radioLabelRoot="true"]': {
+    height: '100%',
+    overflow: 'hidden',
+    display: 'flex',
+    margin: theme.spacing(0),
+    padding: theme.spacing(1, 2),
+    backgroundColor: theme.palette.common.white,
+    boxShadow: `0 0 0 1px ${theme.palette.grey[100]}, 0 1px 1px  ${theme.palette.grey[200]}`,
+    borderRadius: theme.spacing(1),
+    transition: 'all 0.3s',
+
+    '&:has(input[type=radio]:checked)': {
+      backgroundColor: alpha(theme.palette.primary.main, 0.01),
+      boxShadow: `0 0 0 2px ${theme.palette.primary.light}`,
+    },
+    '& .MuiFormControlLabel-label': {
+      width: '100%',
+      maxWidth: '100%',
+    },
+  },
+  '& [data-radioLabelRootActive="true"]': {
+    backgroundColor: alpha(theme.palette.primary.main, 0.01),
+    boxShadow: `0 0 0 2px ${theme.palette.primary.light}`,
+  },
+  '& [data-radioLabelDisabled="true"]': {
+    boxShadow: `0 0 0 1px ${theme.palette.grey[100]}, 0 1px 1px  ${theme.palette.grey[200]}`,
+    '&:hover': {
+      boxShadow: `0 0 0 1px ${theme.palette.grey[100]}, 0 1px 1px  ${theme.palette.grey[200]}`,
+    },
+  },
+  '& [data-radioCardContent="true"]': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+  },
+  '& [data-radioCardContentCenter="true"]': {
+    alignItems: 'center',
+  },
+  '& [data-radioCardContentTop="true"]': {
+    alignItems: 'flex-start',
+  },
+  '& [data-radioCardDetail="true"]': {
+    alignSelf: 'center',
+    textAlign: 'left',
+    flexGrow: 1,
+    maxWidth: '100%',
+  },
+  '& [data-radioCardDetailWithIcon="true"]': {
+    flex: `0 0 calc( 100% - ${theme.spacing(8)}px )`,
+    maxWidth: `calc( 100% - ${theme.spacing(8)}px )`,
+  },
+  '& .radioCardTitle': {
+    flexGrow: 1,
+  },
+  '& .radioCardActions': {
+    marginLeft: theme.spacing(1),
+  },
+  '& .radioCardIcon': {
+    display: 'flex',
+    maxWidth: theme.spacing(6),
+  },
+  '& [data-radioIndicator="true"]': {
+    position: 'absolute',
+    right: theme.spacing(1),
+    display: 'flex',
+    alignItems: 'center',
+  },
+  '& [data-radioIndicatorVisible="true"]': {
+    display: 'flex',
+  },
+  '& [data-radioIndicatorHidden="true"]': {
+    display: 'none',
+  },
+  '& [data-radioIndicatorCenter="true"]': {
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
+  '& [data-radioIndicatorTop="true"]': {
+    top: 0,
+  },
+  '& [data-radioLabelRootIndicator="true"]': {
+    paddingRight: theme.spacing(6),
+  },
+  '& .radioDetailContent': {
+    marginTop: theme.spacing(1),
+  },
+  '& [data-checkboxIndicator="true"]': {
+    position: 'absolute',
+    right: theme.spacing(1),
+    display: 'flex', // Change from 'none' to 'flex'
+    alignItems: 'center',
+  },
+  '& [data-checkboxIndicatorVisible="true"]': {
+    display: 'flex',
+  },
+  '& [data-checkboxIndicatorHidden="true"]': {
+    display: 'none', // Add this to explicitly hide when needed
+  },
+  '& [data-checkboxIndicatorCenter="true"]': {
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
+  '& [data-checkboxIndicatorTop="true"]': {
+    top: 0,
+  },
+  '& .radioCardHeading': {
+    display: 'flex',
+  },
+}));

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.test.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadioCard } from './RadioCard';
+
+describe('RadioCard', () => {
+    it('should render children correctly', () => {
+        render(<RadioCard>Test Content</RadioCard>);
+        expect(screen.getByText('Test Content')).toBeInTheDocument();
+    });
+
+    it('should apply custom className', () => {
+        const { container } = render(
+            <RadioCard className="custom-class">Content</RadioCard>
+        );
+        expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    it('should handle click events', () => {
+        const handleClick = jest.fn();
+        render(<RadioCard onClick={handleClick}>Clickable</RadioCard>);
+        
+        fireEvent.click(screen.getByText('Clickable'));
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should respect disabled state', () => {
+        const handleClick = jest.fn();
+        render(
+            <RadioCard disabled onClick={handleClick}>
+                Disabled
+            </RadioCard>
+        );
+        
+        fireEvent.click(screen.getByText('Disabled'));
+        expect(handleClick).not.toHaveBeenCalled();
+    });
+});

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/RadioCard.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { StyledRadioCard } from './RadioCard.styled';
+import {
+  Box,
+  FormControlLabel,
+  RadioProps as MUIRadioProps,
+  Typography,
+} from '@mui/material';
+import { Checkbox } from '../Checkbox';
+import { RadioIndicator } from '../Radio/RadioIndicator';
+
+export interface RadioCardProps
+  extends Pick<MUIRadioProps, 'disabled' | 'value'> {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: React.ReactNode;
+  maxWidth?: number | string;
+  indicator?: boolean;
+  content?: React.ReactNode;
+  actions?: React.ReactNode;
+  active?: boolean;
+  testId: string;
+  iconPlacement?: 'top' | 'center';
+  enableCheckboxMode?: boolean;
+  onToggleSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/**
+ * RadioCard component
+ * @component
+ */
+export const RadioCard = React.forwardRef<HTMLDivElement, RadioCardProps>(
+  (
+    {
+      title,
+      description,
+      disabled,
+      value,
+      icon,
+      maxWidth = '100%',
+      indicator = false,
+      content,
+      actions,
+      active = false,
+      testId,
+      iconPlacement = 'top',
+      enableCheckboxMode = false,
+      onToggleSelect,
+    },
+    _ref
+  ) => {
+    const cardLabel = (
+      <Box
+        data-radioCardContent={true}
+        data-radioCardContentCenter={iconPlacement === 'center'}
+        data-radioCardContentTop={iconPlacement === 'top'}
+        data-testid={testId}
+      >
+        {icon && <Box className="radioCardIcon">{icon}</Box>}
+
+        <Box data-radioCardDetail={true} data-radioCardDetailWithIcon={icon}>
+          <Box className="radioCardHeading">
+            {title && (
+              <Box className="radioCardTitle">
+                <Typography variant="h4">{title}</Typography>
+              </Box>
+            )}
+            {actions && <Box className="radioCardActions">{actions}</Box>}
+          </Box>
+          {description && (
+            <Typography color="secondary" variant="body1">
+              {description}
+            </Typography>
+          )}
+          {content && <Box className="radioDetailContent">{content}</Box>}
+        </Box>
+      </Box>
+    );
+
+    // Only render radio/checkbox as control when NOT showing indicator
+    const actionItem =
+      indicator && !actions ? (
+        enableCheckboxMode ? (
+          <Checkbox
+            checked={active}
+            testId={testId}
+            onChange={onToggleSelect}
+          />
+        ) : (
+          <RadioIndicator color="primary" />
+        )
+      ) : (
+        // Render invisible radio for form functionality
+        <RadioIndicator color="primary" style={{ display: 'none' }} />
+      );
+
+    return (
+      <StyledRadioCard className="radioCard" maxWidth={maxWidth}>
+        <FormControlLabel
+          data-radioLabelRoot={true}
+          data-radioLabelRootActive={active}
+          data-radioLabelRootIndicator={indicator && !actions}
+          data-radioLabelDisabled={disabled}
+          disabled={disabled}
+          value={value}
+          control={actionItem}
+          label={cardLabel}
+          labelPlacement="start"
+        />
+      </StyledRadioCard>
+    );
+  }
+);
+
+RadioCard.displayName = 'RadioCard';

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/index.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioCard/index.tsx
@@ -1,0 +1,1 @@
+export { RadioCard } from './RadioCard';

--- a/choreo-ui/workspaces/libs/design-system/src/components/RadioGroup/RadioGroup.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/RadioGroup/RadioGroup.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
 import { StyledRadioGroup } from './RadioGroup.styled';
+import { RadioGroupProps as MuiRadioGroupProps } from '@mui/material';
 
-export interface RadioGroupProps {
-  /** The content to be rendered within the component */
+export interface RadioGroupProps extends MuiRadioGroupProps {
   children?: React.ReactNode;
-  /** Additional CSS class names */
   className?: string;
-  /** Click event handler */
   onClick?: (event: React.MouseEvent) => void;
-  /** Whether the component is disabled */
   disabled?: boolean;
-  /**
-   * If true, the component will be displayed in a horizontal layout
-   */
   row?: boolean;
-  /**
-   * The sx prop for custom styles
-   */
   sx?: React.CSSProperties;
+  testId: string;
+  direction?: 'row' | 'column';
 }
 
 /**

--- a/choreo-ui/workspaces/libs/design-system/src/components/index.tsx
+++ b/choreo-ui/workspaces/libs/design-system/src/components/index.tsx
@@ -34,3 +34,4 @@ export * from './DataTable';
 export * from './Divider';
 export * from './Skeleton';
 export * from './ErrorCard';
+export * from './RadioCard';


### PR DESCRIPTION
## Purpose
> This PR introduces a new `RadioCard` component to the design system. The goal is to provide a visually enhanced radio selection UI, supporting card-like layouts, icons, and the ability to add actions or custom content. This addresses the need for more flexible and interactive selection controls in forms and dashboards within OpenChoreo.

## Approach
> - Added the `RadioCard` component with support for title, description, icon, placement options, custom content, actions, and selectable indicator (radio/checkbox).
> - Integrated comprehensive Storybook stories (`RadioCard.stories.tsx`) showcasing vertical, horizontal, indicator, and checkbox modes, as well as advanced content and action placements.
> - Implemented unit tests (`RadioCard.test.tsx`) to ensure correct rendering, click handling, className assignment, and disabled state.
> - Provided custom styles via `RadioCard.styled.tsx` for flexible theming and responsive layouts.
> - Registered and exported `RadioCard` in the design system’s main index for wider usage.
> - Updated the `RadioGroup` API to improve extensibility.

## Related Issues
> No explicit issues mentioned.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (Storybook stories for the new RadioCard component)

## Remarks
> - The PR is self-contained, introducing the new component, stories, and related tests/styles.
> - No known breaking changes.